### PR TITLE
Fix twemoji icons not rendering

### DIFF
--- a/urlx.css
+++ b/urlx.css
@@ -289,8 +289,8 @@ hr {
 }
 
 .note .emoji .twemoji {
-    width: 70%;
-    height: 70%;
+    width: 32px;
+    height: 32px;
     filter: drop-shadow(2px 2px 1px rgba(0, 0, 0, 0.33))
 }
 


### PR DESCRIPTION
I don't know if anyone had this issue but the icons straight up refused to show up and had a width and height of 0px (at least on Firefox)

Before:
![image](https://user-images.githubusercontent.com/47950669/208899976-e5028272-81d3-4704-b869-e55ed0fd738b.png)

After:
![image](https://user-images.githubusercontent.com/47950669/208899858-293cc79e-1926-4e09-8499-1dc834eaa6af.png)
